### PR TITLE
fix/Left margin alignment on mobile devices

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -49,7 +49,20 @@
 .title {
   margin: 0;
   line-height: 1.15;
-  font-size: 4rem;
+}
+
+/* If the screen size is 601px wide or more, fix the font size */
+@media screen and (min-width: 601px) {
+  .title {
+    font-size: 4rem;
+  }
+}
+
+/* If the screen size is 600px wide or less, vary font size with width */
+@media screen and (max-width: 600px) {
+  .title {
+    font-size: 13vw;
+  }
 }
 
 .title,


### PR DESCRIPTION
Sets the title text size to be a function of the screen width when on a small screen. This has the side-effect of fixing the boxes left margins overflowing the screen.